### PR TITLE
Disable brakeman in Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,3 +3,6 @@ plugins:
   brakeman:
     # Disable brakeman because it only works with full Rails apps
     enabled: false
+  rubocop:
+    enabled: true
+    channel: rubocop-0-74


### PR DESCRIPTION
It's started throwing this error for some reason
```
Please supply the path to a Rails application
```

Brakeman seems to only work with full Rails apps, not gems, anyway. So there is no reason to have it run that I can see.

Also, force rubocop to use a newer version that supports Ruby 2.6