### PR TITLE
New CacheCrispies::Base.dependency_key method

### DIFF
--- a/lib/cache_crispies/base.rb
+++ b/lib/cache_crispies/base.rb
@@ -60,6 +60,21 @@ module CacheCrispies
       to_s.demodulize.chomp('Serializer').underscore.to_sym
     end
 
+    # Get or set a cache key that can be changed whenever an outside dependency
+    # of any kind changes in any way that could change the output of your
+    # serializer. For instance, if a mixin is changed. Or maybe an object
+    # you're serializing has changed it's #to_json method. This key should be
+    # changed accordingly, to bust the cache so that you're not serving stale
+    # data.
+    #
+    # @return [String] a version string in any form
+    def self.dependency_key(key = nil)
+      @dependency_key ||= nil
+      return @dependency_key unless key
+
+      @dependency_key = key.to_s
+    end
+
     # A JSON key to use as a root key on a collection-type serializable. By
     # deafult it's the plural version of .key, but it can be overridden in a
     # subclass to be anything.

--- a/lib/cache_crispies/plan.rb
+++ b/lib/cache_crispies/plan.rb
@@ -57,6 +57,7 @@ module CacheCrispies
         [
           CACHE_KEY_PREFIX,
           serializer.cache_key_base,
+          serializer.dependency_key,
           addons_key,
           cacheable.cache_key
         ].flatten.compact.join(CACHE_KEY_SEPARATOR)

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -71,6 +71,21 @@ describe CacheCrispies::Base do
     end
   end
 
+  describe '.dependency_key' do
+    it 'returns nil by default' do
+      expect(subject.class.dependency_key).to be nil
+    end
+
+    context 'after being set' do
+      let(:key) { SecureRandom.hex }
+      before { subject.class.dependency_key key }
+
+      it 'returns the set value' do
+        expect(subject.class.dependency_key).to be key
+      end
+    end
+  end
+
   describe '.collection_key' do
     it 'pluralizes the #key' do
       expect(subject.class.collection_key).to eq :cache_crispies_tests

--- a/spec/plan_spec.rb
+++ b/spec/plan_spec.rb
@@ -6,6 +6,8 @@ describe CacheCrispies::Plan do
       :cereal
     end
 
+    dependency_key :'v1-beta'
+
     def self.cache_key_addons(options)
       ['addon1', options[:extra_addon]]
     end
@@ -86,6 +88,10 @@ describe CacheCrispies::Plan do
       expect(subject.cache_key).to include serializer.cache_key_base
     end
 
+    it "includes the serializer's #dependency_key" do
+      expect(subject.cache_key).to include 'v1-beta'
+    end
+
     it "includes the addons_key" do
       expect(subject.cache_key).to include(
         Digest::MD5.hexdigest('addon1|addon2')
@@ -104,6 +110,7 @@ describe CacheCrispies::Plan do
       expect(subject.cache_key).to eq(
         'cache-crispies' \
         "+CerealSerializerForPlan-#{Digest::MD5.file(serializer_file_path)}" \
+        '+v1-beta' \
         "+#{Digest::MD5.hexdigest('addon1|addon2')}" \
         '+model-cache-key'
       )
@@ -116,6 +123,7 @@ describe CacheCrispies::Plan do
         expect(subject.cache_key).to eq(
           'cache-crispies' \
           "+CerealSerializerForPlan-#{Digest::MD5.file(serializer_file_path)}" \
+          '+v1-beta' \
           '+model-cache-key'
         )
       end


### PR DESCRIPTION
...to bust the cache for code that is changed outside the scope of the serializers themselves. Because the gem itself can't automatically track those changes.

Closes #1