### PR TITLE
Don't try to serialize nested attributes that are nil

### DIFF
--- a/lib/cache_crispies/hash_builder.rb
+++ b/lib/cache_crispies/hash_builder.rb
@@ -16,6 +16,8 @@ module CacheCrispies
     #
     # @return [Hash]
     def call
+      return unless @serializer.model
+
       hash = {}
 
       serializer.attributes.each do |attrib|

--- a/spec/cache_crispies/base_spec.rb
+++ b/spec/cache_crispies/base_spec.rb
@@ -69,6 +69,26 @@ describe CacheCrispies::Base do
         parent_company: 'Disney probably'
       )
     end
+
+    context 'when nutrition_info is nil' do
+      before { model.nutrition_info = nil }
+
+      it 'serializes to a hash' do
+        expect(subject.as_json).to eq(
+          id: '42',
+          name: 'Cookie Crisp',
+          company: 'General Mills',
+          nested: {
+            nested_again: {
+              deeply_nested: 'TRUE'
+            }
+          },
+          nutrition_info: nil,
+          organic: true,
+          parent_company: 'Disney probably'
+        )
+      end
+    end
   end
 
   describe '.key' do


### PR DESCRIPTION
When serializing a nested object that happens to be nil, don't try to naively serialize it (which results in a `NoMethodError` being thrown, but render a `nil` instead.

```ruby
class ChildSerializer < CacheCrispies::Base
  serialize :field
end

class ParentSerializer < CacheCrispies::Base
  # Optional field
  serialize :child, with: ChildSerializer
end

my_child = OpenStruct.new(field: "My field")

parent = OpenStruct.new(child: my_child)
childless_parent = OpenStruct.new(child: nil)

ParentSerializer.new(parent).as_json
#=> {:child=>{:field=>"My field"}}

ParentSerializer.new(childless_parent).as_json
#=> {:child=>nil}
``` 