### PR TITLE
Optimization: Prefer Enumerable#flat_map

### DIFF
--- a/lib/cache_crispies/base.rb
+++ b/lib/cache_crispies/base.rb
@@ -223,7 +223,8 @@ module CacheCrispies
       from: nil, with: nil, through: nil, to: nil, collection: nil,
       &block
     )
-      attribute_names.flatten.map { |att| att&.to_sym }.map do |attrib|
+      attribute_names.flat_map do |attrib|
+        attrib = attrib&.to_sym
         current_nesting = Array(@nesting).dup
         current_conditions = Array(@conditions).dup
 


### PR DESCRIPTION
We can avoid extra iterations by using `Enumerable#flat_map`
### Before:
```ruby
attribute_names.flatten.map { |att| att&.to_sym }.map { ... }
```
### After:
```ruby
attribute_names.flat_map do |att|
  att = att&.to_sym
  ...
end
```