### PR TITLE
Add ruby 2.7 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ rvm:
   - 2.4.9
   - 2.5.7
   - 2.6.5
+  - 2.7.1
+
 cache: bundler
 gemfile:
   - gemfiles/rails_5.0.gemfile

--- a/spec/cache_crispies/plan_spec.rb
+++ b/spec/cache_crispies/plan_spec.rb
@@ -20,7 +20,7 @@ describe CacheCrispies::Plan do
   let(:model) { OpenStruct.new(name: 'Sugar Smacks', cache_key: model_cache_key) }
   let(:cacheable) { model }
   let(:options) { {} }
-  let(:instance) { described_class.new(serializer, cacheable, options) }
+  let(:instance) { described_class.new(serializer, cacheable, **options) }
   subject { instance }
 
   before do


### PR DESCRIPTION
This PR adds Ruby 2.7.1 to the test matrix on Travis CI and fixes 2.7 kwargs warning in specs.