### PR TITLE
Add cache_key_method configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ end
 
 _`cache_store` is set to `Rails.cache` by default, or `ActiveSupport::Cache::NullStore.new` if `Rails.cache` is `nil`._
 
+### Custom model cache key
+```ruby
+CacheCrispies.configure do |conf|
+  conf.cache_key_method = :custom_cache_key_method_name
+end
+```
+`cache_key_method` must be set to the name of the method the model responds to and returns a string value.
+
+_`cache_key_method` is set to `:cache_key` by default._
+
 Usage
 -----
 ### A simple serializer
@@ -358,6 +368,9 @@ end
 ```
 
 In this scenario, you should include `options[:current_user].id` in the `cache_key_addons`. Otherwise, the user's full name could get cached, and users, who shouldn't see it, would.
+
+It is also possible to configure the method CacheCrispies calls on the model via the `config.cacheable_cache_key`
+configuration option.
 
 ### Bust the Cache Key
 ```ruby

--- a/lib/cache_crispies/configuration.rb
+++ b/lib/cache_crispies/configuration.rb
@@ -6,7 +6,8 @@ module CacheCrispies
   class Configuration
     SETTINGS = [
       :cache_store,
-      :etags
+      :etags,
+      :cache_key_method
     ].freeze
 
     SETTINGS.each do |setting|
@@ -18,11 +19,13 @@ module CacheCrispies
     end
 
     alias etags? etags
+    alias cache_key_method? cache_key_method
 
     # Resets all values to their defaults. Useful for testing.
     def reset!
       @cache_store = Rails.cache || ActiveSupport::Cache::NullStore.new
       @etags = false
+      @cache_key_method = :cache_key
     end
   end
 end

--- a/lib/cache_crispies/plan.rb
+++ b/lib/cache_crispies/plan.rb
@@ -58,7 +58,7 @@ module CacheCrispies
           serializer.cache_key_base,
           serializer.dependency_key,
           addons_key,
-          cacheable.cache_key
+          cacheable_cache_key
         ].flatten.compact.join(CACHE_KEY_SEPARATOR)
     end
 
@@ -101,7 +101,11 @@ module CacheCrispies
     end
 
     def cache?
-      serializer.do_caching? && cacheable.respond_to?(:cache_key)
+      serializer.do_caching? && cacheable.respond_to?(CacheCrispies.config.cache_key_method)
+    end
+
+    def cacheable_cache_key
+      cacheable.public_send(CacheCrispies.config.cache_key_method)
     end
 
     def addons_key

--- a/spec/cache_crispies/configuration_spec.rb
+++ b/spec/cache_crispies/configuration_spec.rb
@@ -39,4 +39,16 @@ describe CacheCrispies::Configuration do
       }.to change { subject.etags }.to true
     end
   end
+
+  describe '#cache_key_method' do
+    it 'is cache_key by default' do
+      expect(subject.cache_key_method).to eq :cache_key
+    end
+
+    it 'can be changed' do
+      expect {
+        subject.cache_key_method = :other_cache_key
+      }.to change { subject.cache_key_method }.to eq :other_cache_key
+    end
+  end
 end

--- a/spec/cache_crispies/plan_spec.rb
+++ b/spec/cache_crispies/plan_spec.rb
@@ -125,6 +125,17 @@ describe CacheCrispies::Plan do
         )
       end
     end
+
+    context 'with a configured cache_key_method' do
+      let(:custom_cache_key) { 'custom-cache-key' }
+      let(:model) { OpenStruct.new(name: 'Sugar Smacks', custom_cache_key: custom_cache_key) }
+
+      it "includes the cacheable #custom_cache_key" do
+        expect(CacheCrispies.config).to receive(:cache_key_method).and_return :custom_cache_key
+
+        expect(subject.cache_key).to include custom_cache_key
+      end
+    end
   end
 
   describe '#cache' do


### PR DESCRIPTION
Hi there,

we have the case currently, that the hard coded call to `cacheable.cache_key` in the `Plan` is not outdating our
cache when we update a model. The reason is, that the `Model#cache_key` value does not change after the model is updated, which is correct behavior for Rails >= 5.2 since the `cache_key` method should be used to for "recyclable" cache keys.

Cache versioning is disabled by default for Rails 5.2, >= 6.0 (`ActiveRecord::Base.cache_versioning = false`).
Cache versioning is enabled by default for Rails >= 6.0 (`ActiveRecord::Base.cache_versioning = true`).

See https://api.rubyonrails.org/v5.2/classes/ActiveRecord/Integration.html#method-i-cache_key

I opened this PR for a few reasons instead of just overwriting `cache_key` on my models:

- I would have to overwrite it for every model or in the base model, which is probably a bad idea for existing applications, that use caching in other cases than serializing models (e.g. rendering views).
- I would loose the recyclable `cache_key` that I'll probably need in another place.
- I think it would be a good thing to be able to change the CacheCrispies default from `cache_key` to `cache_key_with_version` in a future major release.

I had several other solutions in mind to solve this "problem".

- A serializer specific `cache_key` class method, that would enable us to configure the used `cache_key` per serializer.
- Extending the serializer specific `addons` to also get model instance passed into the block.

I did not choose them because from my point of view they have one major draw back, that is:
They are hard to reason about in an inheritance chain of serializers (which I think is even with a simple setup, at least 3 classes deep, `MySerializer < MyBaseSerializer < CacheCrispies::Base`). It is not really clear if such a configuration would be inherited or not.

I also did not chose to extend the `addons` block feature because it takes a single positional argument currently (`options`) and passing it the `model` as second positional parameter would not be consistent with the rest of the API (`show_if` etc..). Would be a little challenge to make this change backwards compatible and consistent with the current api (probably something to consider for a major release?).

Another reason is, I don't think it is neither necessary nor a good thing to animate developers to use different methods on different models to generate the CacheCrispies `cacheable.cache_key`.
With the chosen solution it would be possible to enhance it to support a `Proc` as the `cache_key_method` that is called and gets passed the options and the model instance.