### PR TITLE
Feature: Adding option to pass method as symbol to show_if

### DIFF
--- a/lib/cache_crispies/condition.rb
+++ b/lib/cache_crispies/condition.rb
@@ -26,18 +26,22 @@ module CacheCrispies
     def true_for?(serializer)
       return !!serializer.public_send(block) if block.is_a?(Symbol)
 
-      !!case block.arity
-        when 0
-          block.call
-        when 1
-          block.call(serializer.model)
-        else
-          block.call(serializer.model, serializer.options)
-        end
+      !!execute_block(serializer.model, serializer.options)
     end
 
     private
 
     attr_reader :block
+
+    def execute_block(model, options)
+      case block.arity
+      when 0
+        block.call
+      when 1
+        block.call(model)
+      else
+        block.call(model, options)
+      end
+    end
   end
 end

--- a/lib/cache_crispies/condition.rb
+++ b/lib/cache_crispies/condition.rb
@@ -19,19 +19,20 @@ module CacheCrispies
       block.object_id
     end
 
-    # Test the truthiness of the condition against a model and options
+    # Test the truthiness of the condition against the serializer instance
     #
-    # @param model [Object] typically ActiveRecord::Base, but could be anything
-    # @param options [Hash] any optional values from the serializer instance
+    # @param serializer [Object] CacheCrispies::Base serializer instance
     # @return [Boolean] the condition's truthiness
-    def true_for?(model, options = {})
+    def true_for?(serializer)
+      return !!serializer.public_send(block) if block.is_a?(Symbol)
+
       !!case block.arity
         when 0
           block.call
         when 1
-          block.call(model)
+          block.call(serializer.model)
         else
-          block.call(model, options)
+          block.call(serializer.model, serializer.options)
         end
     end
 

--- a/lib/cache_crispies/hash_builder.rb
+++ b/lib/cache_crispies/hash_builder.rb
@@ -51,7 +51,7 @@ module CacheCrispies
       # show_if block
       attribute.conditions.all? do |cond|
         condition_results.fetch(cond.uid) do
-          cond.true_for?(serializer.model, serializer.options)
+          cond.true_for?(serializer)
         end
       end
     end

--- a/spec/cache_crispies/base_spec.rb
+++ b/spec/cache_crispies/base_spec.rb
@@ -11,7 +11,7 @@ describe CacheCrispies::Base do
 
     show_if -> { true } do
       show_if -> { true } do
-        show_if -> { true } do
+        show_if :visible? do
           serialize :name, from: :brand
         end
       end
@@ -32,6 +32,10 @@ describe CacheCrispies::Base do
 
     def id
       model.id.to_s
+    end
+
+    def visible?
+      true
     end
   end
 

--- a/spec/cache_crispies/condition_spec.rb
+++ b/spec/cache_crispies/condition_spec.rb
@@ -1,7 +1,18 @@
 require 'spec_helper'
 
 describe CacheCrispies::Condition do
+  class TestSerializer < CacheCrispies::Base
+    show_if :boolean_method? do
+      serialize :name
+    end
+
+    def boolean_method?
+    end
+  end
+
   let(:block) { -> {} }
+  let(:model) { OpenStruct.new(name: 'Name') }
+  let(:serializer) { TestSerializer.new(model) }
   subject { described_class.new(block) }
 
   describe '#uid' do
@@ -17,7 +28,7 @@ describe CacheCrispies::Condition do
 
     it 'calls the block with model and options arguments' do
       expect(block).to receive(:call).with(model, options)
-      subject.true_for? model, options
+      subject.true_for? serializer
     end
 
     context 'when the block has one argument' do
@@ -25,7 +36,7 @@ describe CacheCrispies::Condition do
 
       it 'calls the block with the model only' do
         expect(block).to receive(:call).with(model)
-        subject.true_for? model, options
+        subject.true_for? serializer
       end
     end
 
@@ -34,12 +45,21 @@ describe CacheCrispies::Condition do
 
       it 'calls the block with no arguments' do
         expect(block).to receive(:call).with(no_args)
-        subject.true_for? model, options
+        subject.true_for? serializer
+      end
+    end
+
+    context 'when the block is a symbol' do
+      let(:block) { :boolean_method? }
+
+      it 'calls the method on serializer instance' do
+        expect(serializer).to receive(block).with(no_args)
+        subject.true_for? serializer
       end
     end
 
     it 'returns a boolean' do
-      expect(subject.true_for?(model, options)).to be true
+      expect(subject.true_for?(serializer)).to be true
     end
   end
 end


### PR DESCRIPTION
Related to #31 

Before:

```ruby
class SomeSerializer < CacheCrispies::Base
  show_if -> (model, options) { model.published? && options[:current_user].admin? && options[:current_user].active? && options[:current_user].id == model.user_id } do
    serialize :published_at
  end
end
```

After:

```ruby
class SomeSerializer < CacheCrispies::Base
  show_if :include_published_at? do
    serialize :published_at
  end

  def include_published_at?
    model.published? &&
      options[:current_user].admin?  &&
      options[:current_user].active? &&
      options[:current_user].id == model.user_id
  end
end
```