### PR TITLE
Add map option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ end
     serialize :uid, from: :id, to: String
     serialize :name, :company
     serialize :copyright, through: :legal_info
+    serialize :address, map: :full_format
     serialize :spiel do |cereal, _options|
       'Made with whole grains!' if cereal.ingredients[:whole_grains] > 0.000001
     end
@@ -197,6 +198,12 @@ serialize :is_organic, from: :organic?
 serialize :copyright, through: :legal_info
 ```
 _If the `legal_info` method returns `nil`, `copyright` will also be `nil`._
+
+### Map a value via a method on that value
+```ruby
+serialize :address, map: :full_format
+```
+_If the `address` method returns `nil`, the result will also be `nil`._
 
 ### Nest another serializer
 ```ruby

--- a/lib/cache_crispies/attribute.rb
+++ b/lib/cache_crispies/attribute.rb
@@ -13,6 +13,8 @@ module CacheCrispies
     # @param key [Symbol] the JSON key for this attribute
     # @param from [Symbol] the method on the model to call to get the value
     # @param with [CacheCrispies::Base] a serializer to use to serialize the
+    # @param through [Symbol] the method through which to serialize the value
+    # @param map [Symbol] the method to which the value will be mapped further
     # @param to [Class, Symbol] the data type to coerce the value into
     # @param collection [Boolean] force rendering as single or collection
     # @param nesting [Array<Symbol>] the JSON keys this attribute will be
@@ -23,7 +25,7 @@ module CacheCrispies
     #   argument's value
     def initialize(
       key,
-      from: nil, with: nil, through: nil, to: nil, collection: nil,
+      from: nil, with: nil, through: nil, map: nil, to: nil, collection: nil,
       nesting: [], conditions: [],
       &block
     )
@@ -31,6 +33,7 @@ module CacheCrispies
       @method_name = from || key || :itself
       @serializer = with
       @through = through
+      @map = map
       @coerce_to = to
       @collection = collection
       @nesting = Array(nesting)
@@ -43,6 +46,7 @@ module CacheCrispies
       :key,
       :serializer,
       :through,
+      :map,
       :coerce_to,
       :collection,
       :nesting,
@@ -63,6 +67,8 @@ module CacheCrispies
           block.call(target, options)
         elsif through?
           target.public_send(through)&.public_send(method_name)
+        elsif map?
+          target.public_send(method_name)&.public_send(map)
         else
           target.public_send(method_name)
         end
@@ -74,6 +80,10 @@ module CacheCrispies
 
     def through?
       !through.nil?
+    end
+
+    def map?
+      !map.nil?
     end
 
     def block?

--- a/lib/cache_crispies/base.rb
+++ b/lib/cache_crispies/base.rb
@@ -220,7 +220,7 @@ module CacheCrispies
 
     def self.serialize(
       *attribute_names,
-      from: nil, with: nil, through: nil, to: nil, collection: nil,
+      from: nil, with: nil, through: nil, map: nil, to: nil, collection: nil,
       &block
     )
       attribute_names.flat_map do |attrib|
@@ -234,6 +234,7 @@ module CacheCrispies
             from: from,
             with: with,
             through: through,
+            map: map,
             to: to,
             collection: collection,
             nesting: current_nesting,

--- a/spec/cache_crispies/attribute_spec.rb
+++ b/spec/cache_crispies/attribute_spec.rb
@@ -15,6 +15,7 @@ describe CacheCrispies::Attribute do
   let(:from) { nil }
   let(:with) { nil }
   let(:through) { nil }
+  let(:map) { nil }
   let(:to) { nil }
   let(:nesting) { [] }
   let(:conditions) { [] }
@@ -24,6 +25,7 @@ describe CacheCrispies::Attribute do
       from: from,
       with: with,
       through: through,
+      map: map,
       to: to,
       nesting: nesting,
       conditions: conditions
@@ -72,6 +74,23 @@ describe CacheCrispies::Attribute do
 
       context 'when the through method returns nil' do
         let(:model) { OpenStruct.new(branding: nil) }
+
+        it 'returns nil' do
+          expect(subject).to be nil
+        end
+      end
+    end
+
+    context 'with a map: argument' do
+      let(:map) { :branding }
+      let(:model) { OpenStruct.new(name: OpenStruct.new(branding: name)) }
+
+      it 'returns the value from the "map" method on the target' do
+        expect(subject).to eq name
+      end
+
+      context 'when the base method returns nil' do
+        let(:model) { OpenStruct.new(name: nil) }
 
         it 'returns nil' do
           expect(subject).to be nil


### PR DESCRIPTION
This PR adds a `map` option to the serialize calls. 

It is similar to the `through` option, with the difference that the `through` option uses the name of the sub-call, while the `map` option uses the name of the parent call.

In the given example, there can be an address having all discrete fields (streetname, city, ...), and some methods for formatting it (full address, just city and state, ...). Then you can map the address to one of the formatters for serialization, while it keeps the `address` key.