### PR TITLE
Fix incompatibility between two recently merged PRs

### DIFF
--- a/lib/cache_crispies/optional.rb
+++ b/lib/cache_crispies/optional.rb
@@ -23,8 +23,8 @@ module CacheCrispies
     # @param model [Object] typically ActiveRecord::Base, but could be anything
     # @param options [Hash] any optional values from the serializer instance
     # @return [Boolean] the condition's truthiness
-    def true_for?(_model, options = {})
-      included = Array(options.fetch(:include, [])).map(&:to_sym)
+    def true_for?(serializer)
+      included = Array(serializer.options.fetch(:include, [])).map(&:to_sym)
 
       included.include?(key) || included.include?(:*)
     end

--- a/spec/cache_crispies/hash_builder_spec.rb
+++ b/spec/cache_crispies/hash_builder_spec.rb
@@ -177,8 +177,7 @@ describe CacheCrispies::HashBuilder do
                 { name: 'Lactose' },
               ]
             }
-          },
-          health: {}
+          }
         })
       end
     end
@@ -205,8 +204,7 @@ describe CacheCrispies::HashBuilder do
                 { name: 'Lactose' },
               ]
             }
-          },
-          health: {}
+          }
         })
       end
     end


### PR DESCRIPTION
This fixes the fact that PR #22 was written against the internal API that PR #36 changed. Specifically, `#true_for?` should now take a singular serializer argument.

_Note that this fixes an **unreleased** bug_