### PR TITLE
Setting railties gem upper limit to be less than 7.0

### DIFF
--- a/cache_crispies.gemspec
+++ b/cache_crispies.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'railties', '>= 5.0.0', '< 6.2'
+  spec.add_dependency 'railties', '>= 5.0.0', '< 7.0'
   spec.add_dependency 'oj', '~> 3.7'
 
-  spec.add_development_dependency 'activemodel', '>= 5.0.0', '< 6.2'
+  spec.add_development_dependency 'activemodel', '>= 5.0.0', '< 7.0'
   spec.add_development_dependency 'appraisal', '~> 2.2'
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'byebug', '~> 11.0'

--- a/gemfiles/rails_5.0.gemfile.lock
+++ b/gemfiles/rails_5.0.gemfile.lock
@@ -1,9 +1,9 @@
 PATH
-  remote: ..
+  remote: .
   specs:
-    cache_crispies (1.1.4)
+    cache_crispies (1.3.0)
       oj (~> 3.7)
-      railties (>= 5.0.0, < 6.2)
+      railties (>= 5.0.0, < 7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -50,7 +50,7 @@ GEM
     minitest (5.12.2)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
-    oj (3.10.16)
+    oj (3.11.6)
     rack (2.0.7)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -92,11 +92,12 @@ GEM
       thread_safe (~> 0.1)
 
 PLATFORMS
+  arm64-darwin-20
   ruby
   x86_64-darwin-19
 
 DEPENDENCIES
-  activemodel (>= 5.0.0, < 6.2)
+  activemodel (>= 5.0.0, < 7.0)
   appraisal (~> 2.2)
   bundler (~> 2.0)
   byebug (~> 11.0)

--- a/gemfiles/rails_5.1.gemfile.lock
+++ b/gemfiles/rails_5.1.gemfile.lock
@@ -1,9 +1,9 @@
 PATH
-  remote: ..
+  remote: .
   specs:
-    cache_crispies (1.1.4)
+    cache_crispies (1.3.0)
       oj (~> 3.7)
-      railties (>= 5.0.0, < 6.2)
+      railties (>= 5.0.0, < 7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -50,7 +50,7 @@ GEM
     minitest (5.12.2)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
-    oj (3.10.16)
+    oj (3.11.6)
     rack (2.0.7)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -92,11 +92,12 @@ GEM
       thread_safe (~> 0.1)
 
 PLATFORMS
+  arm64-darwin-20
   ruby
   x86_64-darwin-19
 
 DEPENDENCIES
-  activemodel (>= 5.0.0, < 6.2)
+  activemodel (>= 5.0.0, < 7.0)
   appraisal (~> 2.2)
   bundler (~> 2.0)
   byebug (~> 11.0)

--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -1,9 +1,9 @@
 PATH
-  remote: ..
+  remote: .
   specs:
-    cache_crispies (1.1.4)
+    cache_crispies (1.3.0)
       oj (~> 3.7)
-      railties (>= 5.0.0, < 6.2)
+      railties (>= 5.0.0, < 7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -50,7 +50,7 @@ GEM
     minitest (5.12.2)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
-    oj (3.10.16)
+    oj (3.11.6)
     rack (2.0.7)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -92,11 +92,12 @@ GEM
       thread_safe (~> 0.1)
 
 PLATFORMS
+  arm64-darwin-20
   ruby
   x86_64-darwin-19
 
 DEPENDENCIES
-  activemodel (>= 5.0.0, < 6.2)
+  activemodel (>= 5.0.0, < 7.0)
   appraisal (~> 2.2)
   bundler (~> 2.0)
   byebug (~> 11.0)

--- a/gemfiles/rails_6.0.gemfile.lock
+++ b/gemfiles/rails_6.0.gemfile.lock
@@ -1,9 +1,9 @@
 PATH
-  remote: ..
+  remote: .
   specs:
-    cache_crispies (1.1.4)
+    cache_crispies (1.3.0)
       oj (~> 3.7)
-      railties (>= 5.0.0, < 6.2)
+      railties (>= 5.0.0, < 7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -51,7 +51,7 @@ GEM
     minitest (5.12.2)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
-    oj (3.10.16)
+    oj (3.11.6)
     rack (2.0.7)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -94,11 +94,12 @@ GEM
     zeitwerk (2.2.0)
 
 PLATFORMS
+  arm64-darwin-20
   ruby
   x86_64-darwin-19
 
 DEPENDENCIES
-  activemodel (>= 5.0.0, < 6.2)
+  activemodel (>= 5.0.0, < 7.0)
   appraisal (~> 2.2)
   bundler (~> 2.0)
   byebug (~> 11.0)


### PR DESCRIPTION
Since rails 6.2 has been dropped, the next rails version will be 7.0. This PR relaxes the upper limit to 7.0 so projects that are trying latest rails 7-alpha can still use cache-crispies.