### PR TITLE
Splat keyword arguments correctly when initializing a plan for collection

### DIFF
--- a/lib/cache_crispies/collection.rb
+++ b/lib/cache_crispies/collection.rb
@@ -41,7 +41,7 @@ module CacheCrispies
 
     def cached_json
       models_by_cache_key = collection.each_with_object({}) do |model, hash|
-        plan = Plan.new(serializer, model, options)
+        plan = Plan.new(serializer, model, **options)
 
         hash[plan.cache_key] = model
       end


### PR DESCRIPTION
With Ruby 3.1.0 we encountered the following error when enabling caching for collections.

```
ArgumentError:
       wrong number of arguments (given 3, expected 2)
     # ./lib/cache_crispies/plan.rb:19:in `initialize'
     # ./lib/cache_crispies/collection.rb:44:in `new'
     # ./lib/cache_crispies/collection.rb:44:in `block in cached_json'
     # ./lib/cache_crispies/collection.rb:43:in `each'
     # ./lib/cache_crispies/collection.rb:43:in `each_with_object'
     # ./lib/cache_crispies/collection.rb:43:in `cached_json'
     # ./lib/cache_crispies/collection.rb:26:in `as_json'
```

Because the `Collection` does currently not splat the `options` hash to keyword arguments.
I could not come up with a good spec for this case, as the specs for the `Collection` class mock the initialization of the plan itself. If you have a good idea on how to write a spec to avoid a regression I would be happy to add it.

Additional question: What do you think about adding different Gemfiles for different ruby versions?