### PR TITLE
Allow setting a Rails Engine to resolve file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ cacheable.cache_key # typically ActiveRecord::Base#cache_key
 - Changing the `dependency_key` will bust all caches from that serializer
 - Not setting the appropriate value in `cache_key_addons` when the same model + serializer pair could produce different output, depending on options or other factors, will result in stale data
 - Data will be cached in the `Rails.cache` store by default
+- If the serializer is implemented in a Rails Engine instead of the base Rails application, set the engine class in the serializer: `engine MyEngine` (inherited in subclasses)
 
 How To...
 ---------

--- a/lib/cache_crispies/base.rb
+++ b/lib/cache_crispies/base.rb
@@ -64,6 +64,21 @@ module CacheCrispies
       alias do_caching? do_caching
     end
 
+    # Get or set root path of Rails application or engine.
+    # It uses Rails by default, but can be overriden with your Rails Engine class.
+    # Calling the method with an argument will set the value, calling it without
+    # any arguments will get the value.
+    def self.engine(value = nil)
+      @engine ||= superclass.try(:engine)
+      @engine ||= Rails
+
+      # method called with no args so act as a getter
+      return @engine if value.nil?
+
+      # method called with args so act as a setter
+      @engine = value
+    end
+
     # Get or set a JSON key to use as a root key on a non-collection
     # serializable. By default it's the name of the class without the
     # "Serializer" part. But it can be overridden in a subclass to be anything.
@@ -190,7 +205,7 @@ module CacheCrispies
         parts = %w[app serializers]
         parts += to_s.deconstantize.split('::').map(&:underscore)
         parts << "#{to_s.demodulize.underscore}.rb"
-        Rails.root.join(*parts)
+        engine.root.join(*parts)
       end
     end
     private_class_method :path

--- a/spec/cache_crispies/base_spec.rb
+++ b/spec/cache_crispies/base_spec.rb
@@ -39,6 +39,15 @@ describe CacheCrispies::Base do
     end
   end
 
+  class MyEngine
+    def self.root
+    end
+  end
+
+  class CacheCrispiesEngineTestSerializer < CacheCrispiesTestSerializer
+    engine MyEngine
+  end
+
   let(:model) do
     OpenStruct.new(
       id: 42,
@@ -52,6 +61,7 @@ describe CacheCrispies::Base do
   end
 
   let(:serializer) { CacheCrispiesTestSerializer }
+  let(:engine_serializer) { CacheCrispiesEngineTestSerializer }
   let(:instance) { serializer.new(model) }
   subject { instance }
 
@@ -161,6 +171,24 @@ describe CacheCrispies::Base do
     end
   end
 
+  describe '.engine' do
+    it 'defaults to Rails' do
+      expect(serializer.engine).to eq Rails
+    end
+
+    context 'when called with an argument' do
+      after { serializer.remove_instance_variable :@engine }
+
+      it 'sets and returns a value' do
+        expect {
+          serializer.engine MyEngine
+        }.to change {
+          serializer.engine
+        }.from(Rails).to MyEngine
+      end
+    end
+  end
+
   describe '.cache_key_addons' do
     it 'returns an empty array by default' do
       expect(serializer.cache_key_addons).to eq []
@@ -203,6 +231,12 @@ describe CacheCrispies::Base do
     let(:serializer_file_digest) {
       Digest::MD5.file(serializer_file_path).to_s
     }
+    let(:engine_serializer_file_path) {
+      File.expand_path('../fixtures/engine_test_serializer.rb', __dir__)
+    }
+    let(:engine_serializer_file_digest) {
+      Digest::MD5.file(engine_serializer_file_path).to_s
+    }
 
     before do
       allow(NutritionSerializer).to receive(:file_hash).and_return(
@@ -210,6 +244,9 @@ describe CacheCrispies::Base do
       )
       allow(Rails).to receive_message_chain(:root, :join).and_return(
         serializer_file_path
+      )
+      allow(MyEngine).to receive_message_chain(:root, :join).and_return(
+        engine_serializer_file_path
       )
     end
 
@@ -229,6 +266,12 @@ describe CacheCrispies::Base do
       expect(serializer.cache_key_base).to eq(
         "#{serializer}-#{serializer_file_digest}+#{nested_serializer_digest}"
       )
+    end
+
+    context 'when an engine is set' do
+      it "includes a digest of the serializer class file's contents" do
+        expect(engine_serializer.cache_key_base).to include engine_serializer_file_digest
+      end
     end
   end
 

--- a/spec/fixtures/engine_test_serializer.rb
+++ b/spec/fixtures/engine_test_serializer.rb
@@ -1,0 +1,3 @@
+# Nothing has to actually be in this file.
+# It's just here so test can MD5 sum it's content.
+# This is an alternative serializer file.


### PR DESCRIPTION
When using CacheCrispies inside a Rails application that is split up in Rails Engines, the file path resolved is not correct: the assumption is made that serializers always reside under the Rails application root (`Rails.root.join("app/serializers")`), while they could actually reside under the engine root.
This PR introduces a method on serializer classes that allow to set the Engine class in order to resolve the file path correctly. This value is inherited when subclassing serializers.

```ruby
class RailsSerializer
end

# Assuming MyApp::Engine resides under `components` directory in Rails root
class EngineSerializer
  engine MyApp::Engine
end

RailsSerializer.send(:path)
# => #<Pathname:/app/serializers/rails_serializer.rb>

EngineSerializer.send(:path)
# => #<Pathname:/components/app/serializers/engine_serializer.rb>
```