### PR TITLE
Allow overriding serializer key with empty value

### DIFF
--- a/lib/cache_crispies.rb
+++ b/lib/cache_crispies.rb
@@ -12,6 +12,9 @@ module CacheCrispies
   # The string to use to join parts of the cache keys together
   CACHE_KEY_SEPARATOR = '+'
 
+  # Magic value for undefined arguments
+  UNDEFINED = Object.new.freeze
+
   require 'cache_crispies/version'
 
   # Use autoload for better Rails development

--- a/lib/cache_crispies/controller.rb
+++ b/lib/cache_crispies/controller.rb
@@ -30,7 +30,7 @@ module CacheCrispies
     def cache_render(
       serializer,
       cacheable,
-      key: nil, collection: nil, status: nil,
+      key: UNDEFINED, collection: nil, status: nil,
       meta: {}, meta_key: :meta,
       **options
     )

--- a/lib/cache_crispies/plan.rb
+++ b/lib/cache_crispies/plan.rb
@@ -16,7 +16,7 @@ module CacheCrispies
     #   data under
     # @option options [Boolean] :collection whether to render the data as a
     #   collection/array or a single object
-    def initialize(serializer, cacheable, key: nil, collection: nil, **options)
+    def initialize(serializer, cacheable, key: UNDEFINED, collection: nil, **options)
       @serializer = serializer
       @cacheable = cacheable
 
@@ -91,7 +91,7 @@ module CacheCrispies
     private
 
     def key
-      return @key unless @key.nil?
+      return @key unless @key == UNDEFINED
 
       (collection? ? serializer.collection_key : serializer.key)
     end

--- a/spec/cache_crispies/controller_spec.rb
+++ b/spec/cache_crispies/controller_spec.rb
@@ -73,6 +73,36 @@ describe CacheCrispies::Controller do
       subject.cache_render CerealSerializerForController, collection.first
     end
 
+    context 'with a key: option'do
+      context 'overriding the key in the serializer' do
+        it 'renders a json collection' do
+          expect(subject).to receive(:render).with json: { serials: cereal_names.map { |name| { name: name } } }.to_json
+
+          subject.cache_render CerealSerializerForController, collection, key: "serials"
+        end
+
+        it 'renders a single json object' do
+          expect(subject).to receive(:render).with json: { serial: { name: cereal_names.first} }.to_json
+
+          subject.cache_render CerealSerializerForController, collection.first, key: "serial"
+        end
+      end
+
+      context 'set to nil' do
+        it 'renders a json collection' do
+          expect(subject).to receive(:render).with json: cereal_names.map { |name| { name: name } }.to_json
+
+          subject.cache_render CerealSerializerForController, collection, key: nil
+        end
+
+        it 'renders a single json object' do
+          expect(subject).to receive(:render).with json: { name: cereal_names.first }.to_json
+
+          subject.cache_render CerealSerializerForController, collection.first, key: nil
+        end
+      end
+    end
+
     context 'with a status: option' do
       it 'passes the status option to the Rails render call' do
         expect(subject).to receive(:render).with(


### PR DESCRIPTION
Allow specifying an empty key in the controller, overriding a key set (or automatically generated) in the serializer class.

```ruby
class PersonSerializer < CacheCrispies::Base
  key :person

  serialize :name
end

cache_render Person.new(name: "John Doe")
# => { person: { name: "John Doe" } }

cache_render Person.new(name: "John Doe"), key: nil
# => { name: "John Doe" }
```