### PR TITLE
Raise error when redefining attribute

### DIFF
--- a/lib/cache_crispies/base.rb
+++ b/lib/cache_crispies/base.rb
@@ -229,6 +229,8 @@ module CacheCrispies
         current_nesting = Array(@nesting).dup
         current_conditions = Array(@conditions).dup
 
+        raise ArgumentError, "Serializable attribute of '#{attrib}' already defined in class #{name}" if @attributes.any? { |a| a.key == attrib }
+
         @attributes <<
           Attribute.new(
             attrib,

--- a/spec/cache_crispies/base_spec.rb
+++ b/spec/cache_crispies/base_spec.rb
@@ -245,6 +245,10 @@ describe CacheCrispies::Base do
       )
     end
 
+    it 'raises an error when redefining an attribute' do
+      expect { instance.class.send(:serialize, :id) }.to raise_error ArgumentError
+    end
+
     it 'contains the correct attribute values' do
       expect(subject[0].method_name).to eq :id
       expect(subject[0].key).to eq :id


### PR DESCRIPTION
At the moment, if an attribute is redefined nothing special happens. The attribute still gets serialized, but the last definition will override the earlier in the final hash. Instead, the gem should warn the user when an attributes is redefined.