### PR TITLE
Direct JSON rendering with Oj::StringWriter

### DIFF
--- a/lib/cache_crispies.rb
+++ b/lib/cache_crispies.rb
@@ -25,6 +25,7 @@ module CacheCrispies
   autoload :Optional,       'cache_crispies/optional'
   autoload :Configuration,  'cache_crispies/configuration'
   autoload :HashBuilder,    'cache_crispies/hash_builder'
+  autoload :JsonBuilder,    'cache_crispies/json_builder'
   autoload :Memoizer,       'cache_crispies/memoizer'
   autoload :Controller,     'cache_crispies/controller'
   autoload :Plan,           'cache_crispies/plan'

--- a/lib/cache_crispies/base.rb
+++ b/lib/cache_crispies/base.rb
@@ -23,7 +23,7 @@ module CacheCrispies
     class << self
       attr_reader :attributes
     end
-    delegate :attributes, :attributes_by_nesting, to: :class
+    delegate :attributes, to: :class
 
     # Initializes a new instance of CacheCrispies::Base, or really, it should
     # always be a subclass of CacheCrispies::Base.
@@ -210,6 +210,7 @@ module CacheCrispies
         attributes.sort_by(&:nesting).group_by(&:nesting)
       )
     end
+    delegate :attributes_by_nesting, to: :class
 
     private
 

--- a/lib/cache_crispies/collection.rb
+++ b/lib/cache_crispies/collection.rb
@@ -29,6 +29,22 @@ module CacheCrispies
       end
     end
 
+    # Renders the collection to an Oj::StringWriter instance without caching
+    #
+    # @return [Oj::StringWriter] an Oj::StringWriter instance with the
+    #   serialized content
+    def write_to_json(json_writer = nil)
+      json_writer ||= Oj::StringWriter.new(mode: :rails)
+      json_writer.push_array
+
+      collection.each do |model|
+        serializer.new(model, options).write_to_json(json_writer)
+      end
+
+      json_writer.pop
+      json_writer
+    end
+
     private
 
     attr_reader :collection, :serializer, :options

--- a/lib/cache_crispies/hash_builder.rb
+++ b/lib/cache_crispies/hash_builder.rb
@@ -16,7 +16,7 @@ module CacheCrispies
     #
     # @return [Hash]
     def call
-      return unless @serializer.model
+      return if @serializer.model.nil?
 
       hash = {}
 
@@ -42,7 +42,7 @@ module CacheCrispies
       hash
     end
 
-    private
+    protected
 
     attr_reader :serializer, :condition_results
 
@@ -56,18 +56,19 @@ module CacheCrispies
       end
     end
 
-    def value_for(attribute)
+    def target_for(attribute)
       meth = attribute.method_name
 
-      target =
-        if meth != :itself && serializer.respond_to?(meth)
-          serializer
-        else
-          serializer.model
-        end
+      if serializer.respond_to?(meth) && meth != :itself
+        serializer
+      else
+        serializer.model
+      end
+    end
 
+    def value_for(attribute)
       # TODO: rescue NoMethodErrors here with something more telling
-      attribute.value_for(target, serializer.options)
+      attribute.value_for(target_for(attribute), serializer.options)
     end
   end
 end

--- a/lib/cache_crispies/json_builder.rb
+++ b/lib/cache_crispies/json_builder.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module CacheCrispies
+  # Builds out a JSON string directly with Oj::StringWriter
+  class JsonBuilder < HashBuilder
+    # Builds the JSON string with Oj::StringWriter
+    #
+    # @return [Oj::StringWriter]
+    def call(json_writer, flat: false)
+      if @serializer.model.nil?
+        json_writer.push_value(nil)
+        return
+      end
+
+      json_writer.push_object unless flat
+
+      last_nesting = []
+
+      serializer.attributes_by_nesting.each do |nesting, attributes|
+        prefix_length = common_prefix_length(last_nesting, nesting)
+
+        (last_nesting.length - prefix_length).times do
+          json_writer.pop
+        end
+
+        nesting[prefix_length..-1].each do |key|
+          json_writer.push_object(key.to_s)
+        end
+
+        attributes.each do |attrib|
+          write_attribute(json_writer, attrib) if show?(attrib)
+        end
+
+        last_nesting = nesting
+      end
+
+      last_nesting.each do
+        json_writer.pop
+      end
+
+      json_writer.pop unless flat
+
+      json_writer
+    end
+
+    protected
+
+    def write_attribute(json_writer, attribute)
+      # TODO: rescue NoMethodErrors here with something more telling
+      attribute.write_to_json(
+        json_writer,
+        target_for(attribute),
+        serializer.options
+      )
+    end
+
+    private
+
+    def common_prefix_length(array1, array2)
+      (0...[array1.length, array2.length].min).each do |i|
+        return i if array1[i] != array2[i]
+      end
+
+      array1.length
+    end
+  end
+end

--- a/lib/cache_crispies/json_builder.rb
+++ b/lib/cache_crispies/json_builder.rb
@@ -57,11 +57,13 @@ module CacheCrispies
     private
 
     def common_prefix_length(array1, array2)
-      (0...[array1.length, array2.length].min).each do |i|
+      shorter_length = [array1.length, array2.length].min
+
+      (0...shorter_length).each do |i|
         return i if array1[i] != array2[i]
       end
 
-      array1.length
+      shorter_length
     end
   end
 end

--- a/spec/cache_crispies/base_spec.rb
+++ b/spec/cache_crispies/base_spec.rb
@@ -105,6 +105,50 @@ describe CacheCrispies::Base do
     end
   end
 
+  describe '#write_to_json' do
+    let(:recovered_hash) { Oj.compat_load(subject.write_to_json.to_s, symbol_keys: true) }
+
+    it 'serializes to an Oj::StringWriter' do
+      expect(subject.write_to_json).to be_kind_of(Oj::StringWriter)
+
+      expect(recovered_hash).to eq(
+        id: '42',
+        name: 'Cookie Crisp',
+        company: 'General Mills',
+        nested: {
+          nested_again: {
+            deeply_nested: 'TRUE'
+          }
+        },
+        nutrition_info: {
+          calories: 1000
+        },
+        organic: true,
+        parent_company: 'Disney probably'
+      )
+    end
+
+    context 'when nutrition_info is nil' do
+      before { model.nutrition_info = nil }
+
+      it 'serializes to an Oj::StringWriter' do
+        expect(recovered_hash).to eq(
+          id: '42',
+          name: 'Cookie Crisp',
+          company: 'General Mills',
+          nested: {
+            nested_again: {
+              deeply_nested: 'TRUE'
+            }
+          },
+          nutrition_info: nil,
+          organic: true,
+          parent_company: 'Disney probably'
+        )
+      end
+    end
+  end
+
   describe '.key' do
     it 'underscores the demodulized class name by default' do
       expect(serializer.key).to eq :cache_crispies_test

--- a/spec/cache_crispies/collection_spec.rb
+++ b/spec/cache_crispies/collection_spec.rb
@@ -80,4 +80,12 @@ describe CacheCrispies::Collection do
       end
     end
   end
+
+  describe '#write_to_json' do
+    let(:recovered_hash) { Oj.compat_load(subject.write_to_json.to_s, symbol_keys: true) }
+
+    it 'serializes to an Oj::StringWriter' do
+      expect(recovered_hash).to eq [{ name: name1 }, { name: name2 }]
+    end
+  end
 end

--- a/spec/cache_crispies/json_builder_spec.rb
+++ b/spec/cache_crispies/json_builder_spec.rb
@@ -1,0 +1,218 @@
+require 'spec_helper'
+
+describe CacheCrispies::JsonBuilder do
+  # These example serializers are meant to show a variety of options,
+  # configurations, and data types in order to really put the HashBuilder class
+  # through the ringer.
+  class ConstituentSerializer < CacheCrispies::Base
+    serialize :name
+  end
+
+  class AllergenSerializer < CacheCrispies::Base
+    serialize :name
+  end
+
+  class BuzzwordSerializer < CacheCrispies::Base
+    serialize :tagline, :small_print
+
+    def tagline
+      "#{model.tagline}#{options[:footnote_marker]}"
+    end
+
+    def small_print
+      "#{options[:footnote_marker]}this doesn't mean jack-squat"
+    end
+  end
+
+  class CerealSerializerForJsonBuilder < CacheCrispies::Base
+    serialize :uid, from: :id, to: String
+    serialize :name, :company
+    merge :itself, with: BuzzwordSerializer
+
+    nest_in :about do
+      nest_in :nutritional_information do
+        serialize :calories
+        serialize :ingredients, with: ConstituentSerializer
+
+        serialize :allergies, with: AllergenSerializer, optional: true
+      end
+    end
+
+    show_if ->(_model, options) { options[:be_trendy] } do
+      nest_in :health do
+        serialize :organic
+
+        show_if ->(model) { model.organic } do
+          serialize :certification
+        end
+      end
+    end
+
+    def certification
+      'Totally Not A Scam Certifiers Inc'
+    end
+  end
+
+  let(:organic) { false }
+  let(:ingredients) {
+    [
+      OpenStruct.new(name: 'Sugar'),
+      OpenStruct.new(name: 'Other Kind of Sugar')
+    ]
+  }
+  let(:allergies) {
+    [
+      OpenStruct.new(name: 'Peanuts'),
+      OpenStruct.new(name: 'Lactose')
+    ]
+  }
+  let(:model) {
+    OpenStruct.new(
+      id: 42,
+      name: 'Lucky Charms',
+      company: 'General Mills',
+      calories: 1_000,
+      organic: organic,
+      tagline: "Part of a balanced breakfast",
+      ingredients: ingredients,
+      allergies: allergies
+    )
+  }
+  let(:options) { { footnote_marker: '*' } }
+  let(:serializer) { CerealSerializerForJsonBuilder.new(model, options) }
+  let(:json_writer) { Oj::StringWriter.new(mode: :rails) }
+  subject { described_class.new(serializer) }
+
+  describe '#call' do
+    let(:recovered_hash) { Oj.compat_load(subject.call(json_writer).to_s, symbol_keys: true) }
+
+    it 'correctly renders the hash' do
+      expect(recovered_hash).to eq ({
+        uid: '42',
+        name: 'Lucky Charms',
+        company: 'General Mills',
+        tagline: 'Part of a balanced breakfast*',
+        small_print: "*this doesn't mean jack-squat",
+        about: {
+          nutritional_information: {
+            calories: 1000,
+            ingredients: [
+              { name: 'Sugar' },
+              { name: 'Other Kind of Sugar' },
+            ]
+          }
+        },
+        health: {}
+      })
+    end
+
+    context 'when the outer show_if is true' do
+      let(:options) { { footnote_marker: '†', be_trendy: true } }
+
+      it 'builds values wrapped in the outer if' do
+        expect(recovered_hash).to eq ({
+          uid: '42',
+          name: 'Lucky Charms',
+          company: 'General Mills',
+          tagline: 'Part of a balanced breakfast†',
+          small_print: "†this doesn't mean jack-squat",
+          about: {
+            nutritional_information: {
+              calories: 1000,
+              ingredients: [
+                { name: 'Sugar' },
+                { name: 'Other Kind of Sugar' },
+              ]
+            }
+          },
+          health: {
+            organic: false
+          }
+        })
+      end
+
+      context 'when the inner show_if is true' do
+        let(:organic) { true }
+
+        it 'builds values wrapped in the outer and inner if' do
+          expect(recovered_hash).to eq ({
+            uid: '42',
+            name: 'Lucky Charms',
+            company: 'General Mills',
+            tagline: 'Part of a balanced breakfast†',
+            small_print: "†this doesn't mean jack-squat",
+            about: {
+              nutritional_information: {
+                calories: 1000,
+                ingredients: [
+                  { name: 'Sugar' },
+                  { name: 'Other Kind of Sugar' },
+                ]
+              }
+            },
+            health: {
+              organic: true,
+              certification: 'Totally Not A Scam Certifiers Inc'
+            }
+          })
+        end
+      end
+    end
+
+    context 'when allergies are included' do
+      let(:options) { { footnote_marker: '*', include: :allergies } }
+
+      it 'includes the allergies' do
+        expect(recovered_hash).to eq ({
+          uid: '42',
+          name: 'Lucky Charms',
+          company: 'General Mills',
+          tagline: 'Part of a balanced breakfast*',
+          small_print: "*this doesn't mean jack-squat",
+          about: {
+            nutritional_information: {
+              calories: 1000,
+              ingredients: [
+                { name: 'Sugar' },
+                { name: 'Other Kind of Sugar' },
+              ],
+              allergies: [
+                { name: 'Peanuts' },
+                { name: 'Lactose' },
+              ]
+            }
+          },
+          health: {}
+        })
+      end
+    end
+
+    context 'when everything is included' do
+      let(:options) { { footnote_marker: '*', include: '*' } }
+
+      it 'includes the allergies' do
+        expect(recovered_hash).to eq ({
+          uid: '42',
+          name: 'Lucky Charms',
+          company: 'General Mills',
+          tagline: 'Part of a balanced breakfast*',
+          small_print: "*this doesn't mean jack-squat",
+          about: {
+            nutritional_information: {
+              calories: 1000,
+              ingredients: [
+                { name: 'Sugar' },
+                { name: 'Other Kind of Sugar' },
+              ],
+              allergies: [
+                { name: 'Peanuts' },
+                { name: 'Lactose' },
+              ]
+            }
+          },
+          health: {}
+        })
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the ability to create a JSON string directly with `Oj::StringWriter`, without building any intermediate hashes. Caching is [feasible](https://github.com/ElMassimo/oj_serializers/blob/e69ae08cb1cd348ede9384ccdbd227bb690753ad/lib/oj_serializers/serializer.rb#L232) but not implemented.

Performance comparison:
```
Document Path:          /courses/cache_crispies
Document Length:        901053 bytes

Concurrency Level:      1
Time taken for tests:   4.073 seconds
Complete requests:      20
Failed requests:        0
Total transferred:      18030040 bytes
HTML transferred:       18021060 bytes
Requests per second:    4.91 [#/sec] (mean)
Time per request:       203.636 [ms] (mean)
Time per request:       203.636 [ms] (mean, across all concurrent requests)
Transfer rate:          4323.27 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       0
Processing:   162  203  42.6    193     330
Waiting:      161  202  42.0    192     325
Total:        162  204  42.6    193     330

Percentage of the requests served within a certain time (ms)
  50%    193
  66%    196
  75%    207
  80%    208
  90%    303
  95%    330
  98%    330
  99%    330
 100%    330 (longest request)


Document Path:          /courses/cache_crispies_oj
Document Length:        901042 bytes

Concurrency Level:      1
Time taken for tests:   3.436 seconds
Complete requests:      20
Failed requests:        0
Total transferred:      18029820 bytes
HTML transferred:       18020840 bytes
Requests per second:    5.82 [#/sec] (mean)
Time per request:       171.787 [ms] (mean)
Time per request:       171.787 [ms] (mean, across all concurrent requests)
Transfer rate:          5124.72 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:   139  172  40.0    157     291
Waiting:      137  170  40.2    156     290
Total:        139  172  40.0    157     291

Percentage of the requests served within a certain time (ms)
  50%    157
  66%    172
  75%    201
  80%    211
  90%    239
  95%    291
  98%    291
  99%    291
 100%    291 (longest request)
```

All records are cached in Redis to avoid disk IO overhead. The latency reduction is over 15%. Here is a brief list of changes (not easy to break into their own commits though):

* A mild refactor of `Attribute` and `HashBuilder`, moving reusable code into separate methods.
* `CacheCrispies::Base.attributes_by_nesting`, which groups attributes by their nesting path to ensure attributes with the same nesting level are written together.
* `CacheCrispies::Base#write_to_json` and `CacheCrispies::Collection#write_to_json`, which serialize the content into a `Oj::StringWriter` and returns it.
* A new class `JsonBuilder`, which uses `serializer.attributes_by_nesting` to write JSON structure directly.
* `Attribute#write_to_json` and `Attribute#write_serialized_value`, which handle the actual writing of values.
* An accidental fix for the issue that `false` is treated equally to `nil` in child serializers. There are applications in the wild that want to convert `false` into something like `{"enabled": false}`.
* Unit tests.

Limitation:
* `show_if -> { false } { nest_in :key { serialize :value } }` will render `key: {}`, because the opening brace has to be emitted before an attribute's condition is evaluated.
* When a merged serializer has an attribute with an identical name to another field in the parent serializer, the key will be emitted twice. That is, `serialize :key; merge :itself, with: AnotherSerializerWhichSerializesKey` results in `key: value, key: value`.