### PR TITLE
Pull request target for GitHub workflows

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,10 +1,6 @@
 name: Ruby
 
-on:
-  push:
-    branches: [ main ]
-  pull_request_target:
-    types: [opened, edited]
+on: [push, pull_request_target]
 
 jobs:
   test:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request_target:
-    types:
-      - opened
+    types: [opened, edited]
 
 jobs:
   test:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [ main ]
   pull_request_target:
-    branches: [ main ]
+    types:
+      - opened
 
 jobs:
   test:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -3,7 +3,7 @@ name: Ruby
 on:
   push:
     branches: [ main ]
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
This should fix the problem with the PRs from forked repositories not having access to the repo secrets. Which has caused failures in Codacy runs.